### PR TITLE
feat(chunk): implement concurrent mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ matrix:
     - node_js: "14"
     - node_js: "12"
 
-script: "npm test -- --coverage"
+script:
+  - "npm test -- --coverage"
+  - "npm run test:experimental"
 after_success: cat ./coverage/lcov.info | npx coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - node_js: "12"
 
 script:
-  - "npm test -- --coverage"
-  - "npm run test:experimental"
+  - npm test -- --coverage && mv ./coverage/coverage-final.json ./coverage/coverage-final-legacy.json
+  - npm run test:experimental -- --coverage && mv ./coverage/coverage-final.json ./coverage/coverage-final-experimental.json
+  - node ./scripts/mergeCoverage.js
 after_success: cat ./coverage/lcov.info | npx coveralls

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,9 +8,9 @@ module.exports = {
     "node_modules",
     "scripts",
   ],
-  "moduleNameMapper": {
+  moduleNameMapper: {
     "^@pexo/utils$": "<rootDir>/packages/utils/src/utils.ts",
     "^@pexo/request$": "<rootDir>/packages/request/src/request.ts",
     "^@pexo/core$": "<rootDir>/packages/core/src/core.ts",
-  }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test:experimental": "PEXO_EXPERIMENTAL=true jest",
     "build": "./scripts/build.sh"
   },
   "author": "Jannick Garthen <jannick.garthen@gmail.com>",
@@ -38,8 +39,6 @@
     "@types/supertest": "^2.0.9",
     "express": "4.17.1",
     "jest": "^26.0.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "supertest": "^4.0.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@types/jest": "^25.2.3",
     "@types/supertest": "^2.0.9",
     "express": "4.17.1",
+    "istanbul-api": "^3.0.0",
+    "istanbul-lib-coverage": "^3.0.0",
     "jest": "^26.0.1",
     "supertest": "^4.0.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,8 +46,6 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/shallowequal": "^1.1.1",
     "@types/styled-components": "^5.1.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "styled-components": "^5.1.0"
   }
 }

--- a/packages/core/src/components/BaseChunk.tsx
+++ b/packages/core/src/components/BaseChunk.tsx
@@ -1,8 +1,19 @@
-import React, { memo } from "react";
+import React, {
+  memo,
+  createContext,
+  useRef,
+  useContext,
+  useState,
+  FC,
+  useReducer,
+} from "react";
 import shallowEqual from "shallowequal";
 import ServerBaseChunk from "./ServerBaseChunk";
 import ClientBaseChunk from "./ClientBaseChunk";
-import { BaseProps } from "./types";
+import ClientBaseChunkSuspense from "./ClientBaseChunk.next";
+import { BaseProps, ChunkModule } from "./types";
+import { generateChunkCacheKey } from "../utils/cacheKey";
+import { useStaticChunkModuleMap } from "../context/StaticChunkModuleCacheContext";
 
 const BaseChunk = <InputProps extends {}, ViewState extends {}>({
   $$name = throwNameNotDefined(),
@@ -12,9 +23,11 @@ const BaseChunk = <InputProps extends {}, ViewState extends {}>({
   actions,
   ...delegateProps
 }: InputProps & BaseProps<InputProps, ViewState>) => {
-  if (!process.browser) {
-    return (
-      <ServerBaseChunk
+  const Component = process.browser ? getClientComponent() : ServerBaseChunk;
+
+  return (
+    <ChunkContextProvider $$name={$$name} delegateProps={delegateProps}>
+      <Component
         $$name={$$name}
         loader={loader}
         redirect={redirect}
@@ -22,24 +35,56 @@ const BaseChunk = <InputProps extends {}, ViewState extends {}>({
         actions={actions}
         {...delegateProps}
       />
-    );
-  }
-  return (
-    <ClientBaseChunk
-      $$name={$$name}
-      loader={loader}
-      redirect={redirect}
-      head={head}
-      actions={actions}
-      {...delegateProps}
-    />
+    </ChunkContextProvider>
   );
 };
 
 const throwNameNotDefined = () => {
   throw new Error(
-    "$$name property is missing on a chunk. This is a required property which should be injected by babel plugin poxy-babel. Most probably it is not present in the babel config."
+    "$$name property is missing on a chunk. This is a required property which should be injected by babel plugin @pexo/babel-transform. Most probably it is not present in the babel config."
   );
+};
+
+const ChunkContext = createContext<{
+  cacheKey: undefined | string;
+  module: undefined | ChunkModule<any, any>;
+  updateModule: (module: ChunkModule<any, any>) => void;
+}>({
+  cacheKey: undefined,
+  module: undefined,
+  updateModule: () => {},
+});
+
+const ChunkContextProvider: FC<{ $$name: string; delegateProps: any }> = ({
+  $$name,
+  delegateProps,
+  children,
+}) => {
+  const cacheKey = generateChunkCacheKey($$name, delegateProps);
+  const staticChunkModuleCache = useStaticChunkModuleMap();
+  const [module, setModule] = useState(staticChunkModuleCache.get($$name));
+  const updateModule = (module: ChunkModule<any, any>) => {
+    staticChunkModuleCache.set($$name, module);
+    setModule(module);
+  };
+  const ctxValue = {
+    cacheKey,
+    module,
+    updateModule,
+  };
+
+  return (
+    <ChunkContext.Provider value={ctxValue}>{children}</ChunkContext.Provider>
+  );
+};
+
+export const useChunkContext = () => useContext(ChunkContext);
+
+const getClientComponent = () => {
+  if (process.env.PEXO_EXPERIMENTAL === "true") {
+    return ClientBaseChunkSuspense;
+  }
+  return ClientBaseChunk;
 };
 
 export default memo(

--- a/packages/core/src/components/ClientBaseChunk.next.tsx
+++ b/packages/core/src/components/ClientBaseChunk.next.tsx
@@ -1,0 +1,256 @@
+import React, {
+  useRef,
+  Suspense,
+  FC,
+  ComponentType,
+  useReducer,
+  useEffect,
+} from "react";
+import { isGeneratorValue } from "@pexo/utils";
+import { useResourceOutdated } from "@pexo/request";
+
+import { useViewStateCacheMap } from "../context/ViewStateCache";
+import { useRequest } from "../context/ClientRequestContext";
+import { useChunkContext } from "./BaseChunk";
+import { BaseProps, ViewActions } from "./types";
+import { useIsVirtualEnvironment } from "../context/VirtualEnvironmentContext";
+import Redirect from "./Redirect";
+import { HeadConsumer } from "../context/ClientHeadContext";
+import { ensureAsync } from "../utils/ensureAsync";
+import { ClientViewStateCacheItem } from "../types/ViewStateCache";
+import { fireAsAct } from "../utils/testing";
+
+const ClientBaseChunk = <InputProps extends {}, ViewState extends {}>(
+  props: InputProps & BaseProps<InputProps, ViewState>
+) => {
+  const hasVisualLoadingState = !props.head && !props.redirect;
+  const { module } = useChunkContext();
+
+  return (
+    <ErrorBoundary View={module?.ErrorView} actions={props.actions}>
+      <Suspense fallback={hasVisualLoadingState ? <Fallback /> : null}>
+        <ChunkViewRenderer {...props} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
+
+const ChunkViewRenderer = <InputProps extends {}, ViewState extends {}>({
+  $$name,
+  loader,
+  redirect,
+  head,
+  actions,
+  ...delegateProps
+}: InputProps & BaseProps<InputProps, ViewState>) => {
+  const View = useModuleLoader(loader, { redirect, head });
+  const data = useViewState(delegateProps);
+  const isVirtualEnvironment = useIsVirtualEnvironment();
+  if (isVirtualEnvironment) {
+    return null;
+  }
+  if (!View) {
+    return null;
+  }
+  return <View actions={actions} {...data?.viewState} />;
+};
+
+const Fallback: FC = () => {
+  const { module } = useChunkContext();
+
+  if (module && module.LoadingView) {
+    return <module.LoadingView />;
+  }
+
+  return null;
+};
+
+interface ErrorBoundaryProps {
+  View?: ComponentType<{ error: unknown; actions?: ViewActions }>;
+  actions?: ViewActions;
+}
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  { error?: unknown }
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {};
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      if (!this.props.View) {
+        return null;
+      }
+      return (
+        <this.props.View
+          error={this.state.error}
+          actions={this.props.actions}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const useModuleLoader = (
+  loader: any,
+  { redirect, head }: { redirect?: boolean; head?: boolean }
+) => {
+  const { module, updateModule } = useChunkContext();
+  if (!module) {
+    throw ensureAsync(loader()).then((m) => updateModule(m));
+  }
+  const View = module.View;
+
+  if (!View && redirect) {
+    return Redirect;
+  }
+
+  if (!View && head) {
+    return HeadConsumer;
+  }
+
+  return View;
+};
+
+interface UpdateViewStateArgs {
+  result?: {};
+  error?: unknown;
+  generator?: AsyncGenerator;
+}
+
+const useViewState = (
+  delegateProps: any
+): ClientViewStateCacheItem | undefined => {
+  const { module, cacheKey } = useChunkContext();
+  const request = useRef(useRequest().clone()).current;
+  const utils = { request };
+  const viewStateCache = useViewStateCacheMap();
+
+  if (!cacheKey) {
+    throw new Error("A chunk should always have a cache key.");
+  }
+
+  const updateViewState = ({
+    result,
+    error,
+    generator,
+  }: UpdateViewStateArgs) => {
+    viewStateCache.set(cacheKey, {
+      viewState: result || {},
+      resourceIds: request.retrieveUsedResourceIds(),
+      updatedAt: Date.now(),
+      error,
+      generator,
+    });
+  };
+
+  const data = viewStateCache.get(cacheKey);
+  useGenerator(data?.generator, {
+    updateViewState,
+    cacheKey,
+  });
+
+  const resourcesAreOutdated = useResourceOutdated(
+    request,
+    data?.resourceIds ?? [],
+    data?.updatedAt
+  );
+
+  if (data && !resourcesAreOutdated) {
+    if (data.error) {
+      throw data.error;
+    }
+    return data;
+  }
+
+  if (!module) {
+    return;
+  }
+
+  if (!module.generateViewState) {
+    return {
+      viewState: {},
+      resourceIds: [],
+      updatedAt: Date.now(),
+    };
+  }
+
+  throw executeGenerateViewState({
+    asyncResult: module.generateViewState(delegateProps, utils),
+    updateViewState,
+  });
+};
+
+const executeGenerateViewState = async ({
+  asyncResult,
+  updateViewState,
+}: {
+  asyncResult: Promise<any>;
+  updateViewState: (config: UpdateViewStateArgs) => void;
+}) => {
+  try {
+    const result = (await asyncResult) ?? {};
+
+    if (isGeneratorValue(result)) {
+      const generator = result;
+      const { value, done } = await generator.next();
+      updateViewState({
+        result: value,
+        generator: !done ? generator : undefined,
+      });
+      return;
+    }
+    updateViewState({ result });
+  } catch (error) {
+    updateViewState({
+      error: error ?? new Error("Failed to execute generateViewState"),
+    });
+  }
+};
+
+const useGenerator = (
+  generator: AsyncGenerator | undefined,
+  {
+    updateViewState,
+    cacheKey,
+  }: {
+    cacheKey: string;
+    updateViewState: (config: UpdateViewStateArgs) => void;
+  }
+) => {
+  const [, forceUpdate] = useReducer((state) => {
+    return state + 1;
+  }, 0);
+  useEffect(() => {
+    if (!generator) {
+      return;
+    }
+    (async () => {
+      try {
+        let lastResult;
+        for await (const viewState of generator) {
+          lastResult = viewState;
+          updateViewState({ result: viewState as {}, generator });
+          fireAsAct(forceUpdate);
+        }
+        updateViewState({ result: lastResult as {}, generator: undefined });
+      } catch (error) {
+        updateViewState({
+          error: error ?? new Error("Failed to execute generateViewState"),
+        });
+        fireAsAct(forceUpdate);
+      }
+    })();
+  }, [cacheKey, generator]);
+};
+
+export default ClientBaseChunk;

--- a/packages/core/src/components/ClientBaseChunk.tsx
+++ b/packages/core/src/components/ClientBaseChunk.tsx
@@ -40,6 +40,7 @@ const ClientBaseChunk = <InputProps extends {}, ViewState extends {}>({
   if (typeof chunkModule === "symbol") {
     return null;
   }
+
   if (redirect) {
     if (status === useViewState.LOADING) {
       return null;
@@ -55,15 +56,15 @@ const ClientBaseChunk = <InputProps extends {}, ViewState extends {}>({
   }
 
   if (status === useViewState.LOADING) {
-    if (chunkModule.Loading) {
-      return <chunkModule.Loading actions={actions} />;
+    if (chunkModule.LoadingView) {
+      return <chunkModule.LoadingView actions={actions} />;
     }
     return null;
   }
 
   if (status === useViewState.ERROR) {
-    if (chunkModule.Error) {
-      return <chunkModule.Error error={data} actions={actions} />;
+    if (chunkModule.ErrorView) {
+      return <chunkModule.ErrorView error={data} actions={actions} />;
     }
     return null;
   }

--- a/packages/core/src/components/Route.tsx
+++ b/packages/core/src/components/Route.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useRef } from "react";
-import ReactDOM from "react-dom";
+import { render, unmountComponentAtNode } from "react-dom";
 import { Route as ReactRouterRoute, useLocation } from "react-router-dom";
 import { createLocation } from "history";
 import { useClientRouterContext } from "../context/ClientRouterContext";
@@ -33,7 +33,7 @@ const usePreFetch = (
       }
       let fragment = document.createDocumentFragment();
       const nextLocation = createLocation(path);
-      ReactDOM.render(
+      render(
         <VirtualEnvironmentProvider>
           <SharedGlobalClientProvider>
             <Component location={nextLocation} />
@@ -43,7 +43,7 @@ const usePreFetch = (
       );
       didPreFetch.current = true;
       return () => {
-        ReactDOM.unmountComponentAtNode(fragment);
+        unmountComponentAtNode(fragment);
         (fragment as any) = null;
       };
     }, [shouldPreFetch, path, Component, didPreFetch]),

--- a/packages/core/src/components/ServerBaseChunk.tsx
+++ b/packages/core/src/components/ServerBaseChunk.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from "react";
 import { isSyncValue } from "@pexo/utils";
-import { generateChunkCacheKey } from "../utils/cacheKey";
 import { ServerChunkRegisterContext } from "../context/ServerChunkRegisterContext";
 import { BaseProps } from "./types";
+import { useChunkContext } from "./BaseChunk";
 
 const ServerBaseChunk = <InputProps extends {}, ViewState extends {}>({
   $$name,
@@ -12,7 +12,7 @@ const ServerBaseChunk = <InputProps extends {}, ViewState extends {}>({
   actions,
   ...delegateProps
 }: InputProps & BaseProps<InputProps, ViewState>) => {
-  const chunkCacheKey = generateChunkCacheKey($$name, delegateProps);
+  const { cacheKey } = useChunkContext();
   const chunkModule = loader();
   if (!isSyncValue(chunkModule)) {
     throw new Error(
@@ -20,9 +20,9 @@ const ServerBaseChunk = <InputProps extends {}, ViewState extends {}>({
     );
   }
   const { registry } = useContext(ServerChunkRegisterContext);
-  registry.set(chunkCacheKey, {
+  registry.set(cacheKey, {
     ...chunkModule,
-    chunkCacheKey,
+    chunkCacheKey: cacheKey,
     chunkName: $$name,
     isRedirect: Boolean(redirect),
     isHead: Boolean(head),
@@ -31,7 +31,7 @@ const ServerBaseChunk = <InputProps extends {}, ViewState extends {}>({
   });
   return (
     <div
-      data-px-server-template-chunk-cache-key={chunkCacheKey}
+      data-px-server-template-chunk-cache-key={cacheKey}
       children="__PX_CHUNK/End__"
     />
   );

--- a/packages/core/src/components/__tests__/ClientBaseChunk.test.tsx
+++ b/packages/core/src/components/__tests__/ClientBaseChunk.test.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import { render, cleanup, act, fireEvent } from "@testing-library/react";
 import { createRequestResource, apply } from "@pexo/request";
-import ClientBaseChunk from "../ClientBaseChunk";
+import BaseChunk from "../BaseChunk";
 import { awaiter } from "../../../__tests__/utils";
 import { useRequest } from "../../context/ClientRequestContext";
 
 describe("ClientBaseChunk", () => {
+  beforeEach(() => {
+    process.browser = true;
+  });
   afterEach(() => {
     cleanup();
+    delete process.browser;
   });
 
-  it("should render a view", () => {
-    const { getByText } = render(
-      <ClientBaseChunk
+  it("should render a view", async () => {
+    const { findByText } = render(
+      <BaseChunk
         $$name={String(performance.now())}
         loader={() => ({
           View: () => <div>Test</div>,
@@ -20,12 +24,12 @@ describe("ClientBaseChunk", () => {
       />
     );
 
-    expect(getByText("Test")).not.toBeNull();
+    expect(await findByText("Test")).not.toBeNull();
   });
 
   it("should render async module view", async () => {
     const { findByText } = render(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={String(performance.now())}
         loader={() =>
           Promise.resolve({
@@ -41,7 +45,7 @@ describe("ClientBaseChunk", () => {
   it("should render loader for async generate view state", async () => {
     const { resolve, promise } = awaiter();
     const { findByText, queryByText } = render(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={String(performance.now())}
         loader={() =>
           Promise.resolve({
@@ -50,7 +54,7 @@ describe("ClientBaseChunk", () => {
               return {};
             },
             View: () => <div>Test</div>,
-            Loading: () => <div>Loading</div>,
+            LoadingView: () => <div>Loading</div>,
           })
         }
       />
@@ -66,7 +70,7 @@ describe("ClientBaseChunk", () => {
   it("should render error for async generate view state that fails", async () => {
     const { reject, promise } = awaiter();
     const { findByText, queryByText } = render(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={String(performance.now())}
         loader={() =>
           Promise.resolve({
@@ -75,15 +79,15 @@ describe("ClientBaseChunk", () => {
               return {};
             },
             View: () => <div>Test</div>,
-            Loading: () => <div>Loading</div>,
-            Error: () => <div>Error</div>,
+            LoadingView: () => <div>Loading</div>,
+            ErrorView: () => <div>Error</div>,
           })
         }
       />
     );
 
-    expect(queryByText("Test")).toBeNull();
     expect(await findByText("Loading")).not.toBeNull();
+    expect(queryByText("Test")).toBeNull();
     act(() => reject());
     expect(await findByText("Error")).not.toBeNull();
     expect(queryByText("Loading")).toBeNull();
@@ -92,7 +96,7 @@ describe("ClientBaseChunk", () => {
   it("should pass the reason for an error to the error component", async () => {
     const { reject, promise } = awaiter();
     const { findByText, queryByText } = render(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={String(performance.now())}
         loader={() =>
           Promise.resolve({
@@ -101,8 +105,8 @@ describe("ClientBaseChunk", () => {
               return {};
             },
             View: () => <div>Test</div>,
-            Loading: () => <div>Loading</div>,
-            Error: ({ error }: { error: string }) => <div>{error}</div>,
+            LoadingView: () => <div>Loading</div>,
+            ErrorView: ({ error }: { error: string }) => <div>{error}</div>,
           })
         }
       />
@@ -118,8 +122,8 @@ describe("ClientBaseChunk", () => {
 
   it("should allow to pass actions into the view", async () => {
     const fire = jest.fn();
-    const { getByText } = render(
-      <ClientBaseChunk
+    const { findByText } = render(
+      <BaseChunk
         $$name={String(performance.now())}
         actions={{ fire }}
         loader={() => ({
@@ -130,14 +134,14 @@ describe("ClientBaseChunk", () => {
       />
     );
 
-    fireEvent.click(getByText("Test"));
+    fireEvent.click(await findByText("Test"));
     expect(fire).toHaveBeenCalledTimes(1);
   });
 
   it("should update view as soon as input props change", async () => {
     const name = String(performance.now());
     const { queryByText, findByText, rerender } = render(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={name}
         value={1}
         loader={() => ({
@@ -149,7 +153,7 @@ describe("ClientBaseChunk", () => {
 
     expect(await findByText("1")).not.toBeNull();
     rerender(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={name}
         value={2}
         loader={() => ({
@@ -166,7 +170,7 @@ describe("ClientBaseChunk", () => {
     const name = String(performance.now());
     const generateViewState = jest.fn(() => ({ value: "Chunk" }));
     const { findByText, rerender } = render(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={name}
         loader={() => ({
           View: ({ value }: { value: string }) => <div>{value}</div>,
@@ -180,7 +184,7 @@ describe("ClientBaseChunk", () => {
     expect(await findByText("reset")).not.toBeNull();
 
     rerender(
-      <ClientBaseChunk
+      <BaseChunk
         $$name={name}
         loader={() => ({
           View: ({ value }: { value: string }) => <div>{value}</div>,
@@ -201,7 +205,7 @@ describe("ClientBaseChunk", () => {
         update: () => Promise.resolve(),
       });
       const { findByText, getByText } = render(
-        <ClientBaseChunk
+        <BaseChunk
           $$name={name}
           loader={() => ({
             View: ({ state }: { state: number }) => {
@@ -242,7 +246,7 @@ describe("ClientBaseChunk", () => {
         }
       );
       const { findByText, getByText } = render(
-        <ClientBaseChunk
+        <BaseChunk
           $$name={name}
           loader={() => ({
             View: ({ state }: { state: number }) => {

--- a/packages/core/src/components/types.d.ts
+++ b/packages/core/src/components/types.d.ts
@@ -7,8 +7,8 @@ interface ViewActions {
 
 export interface ChunkModule<InputProps, ViewState> {
   View: ComponentType<ViewState & { actions?: ViewActions }>;
-  Loading?: ComponentType<{ actions?: ViewActions }>;
-  Error?: ComponentType<{ error: unknown; actions?: ViewActions }>;
+  LoadingView?: ComponentType<{ actions?: ViewActions }>;
+  ErrorView?: ComponentType<{ error: unknown; actions?: ViewActions }>;
   generateViewState?: (
     props: InputProps,
     utils: GenerateViewStateUtils

--- a/packages/core/src/context/StaticChunkModuleCacheContext.tsx
+++ b/packages/core/src/context/StaticChunkModuleCacheContext.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext } from "react";
-import { ChunkModule } from "../../packages/core/src/components/types";
+import { ChunkModule } from "../components/types";
 
 export type StaticChunkModuleCache = Map<string, ChunkModule<any, any>>;
 

--- a/packages/core/src/context/ViewStateCache.tsx
+++ b/packages/core/src/context/ViewStateCache.tsx
@@ -1,14 +1,14 @@
 import React, { FC, useContext } from "react";
-import { ViewStateCache } from "../types/ViewStateCache";
+import { ClientViewStateCache } from "../types/ViewStateCache";
 
-const ViewStateContext = React.createContext<{ cache: ViewStateCache }>({
+const ViewStateContext = React.createContext<{ cache: ClientViewStateCache }>({
   cache: new Map(),
 });
 
 export const useViewStateCacheMap = () => useContext(ViewStateContext).cache;
 
 interface Props {
-  cache: ViewStateCache;
+  cache: ClientViewStateCache;
   children: JSX.Element;
 }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -10,3 +10,4 @@ export {
 } from "./plugins";
 export { useRequest } from "./context/ClientRequestContext";
 export { GenerateViewStateUtils } from "./types/GenerateViewStateUtils";
+export { RedirectChunkViewProps } from "./components/Redirect";

--- a/packages/core/src/server.tsx
+++ b/packages/core/src/server.tsx
@@ -76,14 +76,16 @@ export const createStreamMiddleware = (config: MiddlewareConfig) => {
           <PxGlobalServerProvider>{chunkNode}</PxGlobalServerProvider>
         </StaticRouter>
       );
-      const orderedChunks = renderStaticChunkTemplate({
-        createApp,
-        createAppContext,
-        shouldRenderRoutesOnly: shouldRenderRoutesOnly
-          ? "routes"
-          : renderTemplate,
-        plugins,
-      });
+      const orderedChunks = disableServerSideRendering
+        ? []
+        : renderStaticChunkTemplate({
+            createApp,
+            createAppContext,
+            shouldRenderRoutesOnly: shouldRenderRoutesOnly
+              ? "routes"
+              : renderTemplate,
+            plugins,
+          });
 
       let headConfig = {};
       if (!disableServerSideRendering && !shouldRenderRoutesOnly) {

--- a/packages/core/src/types/ViewStateCache.ts
+++ b/packages/core/src/types/ViewStateCache.ts
@@ -6,3 +6,13 @@ export type ViewStateCache = Map<
     updatedAt: number;
   }
 >;
+
+export type ClientViewStateCacheItem = {
+  viewState: {};
+  resourceIds: string[];
+  updatedAt: number;
+  generator?: AsyncGenerator;
+  error?: unknown;
+};
+
+export type ClientViewStateCache = Map<string, ClientViewStateCacheItem>;

--- a/packages/example/chunks/chunk1.tsx
+++ b/packages/example/chunks/chunk1.tsx
@@ -23,6 +23,10 @@ export const View: FC<Props> = ({ title, subTitle }) => (
   </Wrapper>
 );
 
+export const ErrorView = () => {
+  return <div>:(</div>;
+};
+
 interface InputProps {
   page?: string;
 }

--- a/packages/example/chunks/chunk2.tsx
+++ b/packages/example/chunks/chunk2.tsx
@@ -39,3 +39,7 @@ export const generateViewState = async function* (inputProps: InputProps) {
     even: inputProps.value % 2 === 0,
   };
 };
+
+export const ErrorView = () => {
+  return <div>:(</div>;
+};

--- a/packages/example/chunks/redirect.tsx
+++ b/packages/example/chunks/redirect.tsx
@@ -1,4 +1,4 @@
-import { RedirectChunkViewProps } from "../../packages/core/src/components";
+import { RedirectChunkViewProps } from "@pexo/core";
 
 interface InputProps {
   pathname: string;

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "private": true,
   "scripts": {
-    "start": "pexo develop --server-entry ./server.tsx --client-entry ./client.tsx",
-    "build": "pexo build --server-entry ./server.tsx --client-entry ./client.tsx"
+    "start": "PEXO_EXPERIMENTAL=true pexo develop --server-entry ./server.tsx --client-entry ./client.tsx",
+    "build": "PEXO_EXPERIMENTAL=true pexo build --server-entry ./server.tsx --client-entry ./client.tsx"
   },
   "targets": {
     "server": {
@@ -35,8 +35,8 @@
     "@babel/preset-typescript": "^7.9.0",
     "@pexo/babel-transform": "^0.0.0-alpha.1",
     "@pexo/cli": "^0.0.0-alpha.1.2",
-    "@pexo/parcel-runtime-dynamic-imports": "^0.0.0-alpha.1.3",
     "@pexo/parcel-reporter-manifest": "^0.0.0-alpha.1.3",
+    "@pexo/parcel-runtime-dynamic-imports": "^0.0.0-alpha.1.3",
     "@types/commander": "^2.12.2",
     "@types/supertest": "^2.0.9",
     "jest": "^26.0.1",
@@ -44,13 +44,13 @@
     "typescript": "^3.9.2"
   },
   "dependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "styled-components": "^5.1.0",
     "@pexo/core": "^0.0.0-alpha.5.3",
     "@pexo/request": "^0.0.0-alpha.3.3",
     "express": "^4.17.1",
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^2.2.1",
+    "react": "^0.0.0-experimental-33c3af284",
+    "react-dom": "^0.0.0-experimental-33c3af284",
+    "styled-components": "^5.1.0"
   },
   "alias": {
     "@pexo/core": "../core/src/core.ts",

--- a/packages/example/server.tsx
+++ b/packages/example/server.tsx
@@ -27,7 +27,7 @@ expressApp.use(
 if (process.env.NODE_ENV !== "production") {
   expressApp.use(
     "/__parcel_source_root",
-    express.static(path.join(process.cwd()), {
+    express.static(path.join(process.cwd(), '../..'), {
       maxAge: 2500,
     })
   );

--- a/packages/request/src/caches.ts
+++ b/packages/request/src/caches.ts
@@ -7,7 +7,7 @@ export interface AsyncCache {
   get: (key: string) => Promise<CacheItem<any> | undefined>;
   set: <T = unknown>(key: string, item: CacheItem<T>) => Promise<void>;
   delete: (key: string) => Promise<void>;
-  entries: () => Promise<(readonly [string, CacheItem<any>])[]>;
+  entries: () => Promise<[string, CacheItem<any>][]>;
 }
 
 export interface SyncCache {
@@ -30,7 +30,8 @@ export const createAsyncCache = (): AsyncCache => {
     entries: () => {
       return Promise.all(
         Array.from(cache.entries()).map(
-          async ([key, asyncValue]) => [key, await asyncValue] as const
+          async ([key, asyncValue]) =>
+            [key, await asyncValue] as [string, CacheItem<any>]
         )
       );
     },

--- a/scripts/mergeCoverage.js
+++ b/scripts/mergeCoverage.js
@@ -1,0 +1,18 @@
+// @see https://github.com/facebook/jest/issues/2418#issuecomment-276056758
+const createReporter = require("istanbul-api").createReporter;
+const istanbulCoverage = require("istanbul-lib-coverage");
+
+const map = istanbulCoverage.createCoverageMap();
+const reporter = createReporter();
+
+const files = [
+  require("../coverage/coverage-final-legacy.json"),
+  require("../coverage/coverage-final-experimental.json"),
+];
+
+files.forEach((file) => {
+  Object.keys(file).forEach((filename) => map.addFileCoverage(file[filename]));
+});
+
+reporter.addAll(["json", "lcov", "text"]);
+reporter.write(map);

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,7 +40,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.3.3", "@babel/generator@^7.9.6":
+"@babel/generator@^7.0.0", "@babel/generator@^7.3.3", "@babel/generator@^7.4.0", "@babel/generator@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
   integrity sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==
@@ -269,7 +269,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
   integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
@@ -868,7 +868,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.0.0", "@babel/template@^7.2.2", "@babel/template@^7.3.3", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
+"@babel/template@^7.0.0", "@babel/template@^7.2.2", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
   integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
@@ -877,7 +877,7 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.2.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.8.3", "@babel/traverse@^7.9.6":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.2.3", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.8.3", "@babel/traverse@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
   integrity sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
@@ -892,7 +892,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
   integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
@@ -2347,6 +2347,13 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  integrity sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==
+  dependencies:
+    default-require-extensions "^2.0.0"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -2455,6 +2462,13 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async@^2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -3083,6 +3097,11 @@ commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+compare-versions@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -3544,6 +3563,13 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
+  integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
+  dependencies:
+    strip-bom "^3.0.0"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -4104,6 +4130,14 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+fileset@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
+  integrity sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=
+  dependencies:
+    glob "^7.0.3"
+    minimatch "^3.0.3"
+
 filesize@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
@@ -4329,7 +4363,7 @@ glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -5039,10 +5073,55 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+istanbul-api@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-3.0.0.tgz#eca53a6d3995eb39d59f2a9c1ee7071877770550"
+  integrity sha512-6KTQT5osUuuDT1ybWvrzJIXljrzDiZTHLxUkEr6WY1lAO2Q3PzZCH5+gSAEOaUhJf+qbaC79rQyCNeHGB6+6gw==
+  dependencies:
+    async "^2.6.2"
+    compare-versions "^3.4.0"
+    fileset "^2.0.3"
+    istanbul-lib-coverage "^2.0.5"
+    istanbul-lib-hook "^2.0.7"
+    istanbul-lib-instrument "^3.3.0"
+    istanbul-lib-report "^2.0.8"
+    istanbul-lib-source-maps "^3.0.6"
+    istanbul-reports "^2.2.5"
+    js-yaml "^3.13.1"
+    make-dir "^2.1.0"
+    minimatch "^3.0.4"
+    once "^1.4.0"
+    semver "^6.0.0"
+
+istanbul-lib-coverage@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
+  integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
+
 istanbul-lib-coverage@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
   integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+
+istanbul-lib-hook@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz#c95695f383d4f8f60df1f04252a9550e15b5b133"
+  integrity sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==
+  dependencies:
+    append-transform "^1.0.0"
+
+istanbul-lib-instrument@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
+  integrity sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
+  dependencies:
+    "@babel/generator" "^7.4.0"
+    "@babel/parser" "^7.4.3"
+    "@babel/template" "^7.4.0"
+    "@babel/traverse" "^7.4.3"
+    "@babel/types" "^7.4.0"
+    istanbul-lib-coverage "^2.0.5"
+    semver "^6.0.0"
 
 istanbul-lib-instrument@^4.0.0:
   version "4.0.3"
@@ -5054,6 +5133,15 @@ istanbul-lib-instrument@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     semver "^6.3.0"
 
+istanbul-lib-report@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
+  integrity sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
+  dependencies:
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    supports-color "^6.1.0"
+
 istanbul-lib-report@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
@@ -5063,6 +5151,17 @@ istanbul-lib-report@^3.0.0:
     make-dir "^3.0.0"
     supports-color "^7.1.0"
 
+istanbul-lib-source-maps@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
+  integrity sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    rimraf "^2.6.3"
+    source-map "^0.6.1"
+
 istanbul-lib-source-maps@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9"
@@ -5071,6 +5170,13 @@ istanbul-lib-source-maps@^4.0.0:
     debug "^4.1.1"
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
+
+istanbul-reports@^2.2.5:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.7.tgz#5d939f6237d7b48393cc0959eab40cd4fd056931"
+  integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
+  dependencies:
+    html-escaper "^2.0.0"
 
 istanbul-reports@^3.0.2:
   version "3.0.2"
@@ -5703,7 +5809,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5734,6 +5840,14 @@ lowlight@~1.9.0:
   dependencies:
     fault "^1.0.2"
     highlight.js "~9.12.0"
+
+make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -5890,7 +6004,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4:
+minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6468,6 +6582,11 @@ picomatch@^2.0.4, picomatch@^2.0.5:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -7364,7 +7483,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@^2.6.2:
+rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -7460,7 +7579,7 @@ scheduler@0.0.0-experimental-33c3af284:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.7.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -7913,6 +8032,11 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-bom@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7067,15 +7067,14 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+react-dom@^0.0.0-experimental-33c3af284:
+  version "0.0.0-experimental-33c3af284"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-33c3af284.tgz#d4acd21209a299832d9233ceafc25a6fe1b1d076"
+  integrity sha512-z1/EQD8iKjqkRRd/lEs6oh4FNcS9tPmO91219w4UlLhP0g28wTWClJOYDEnKgQh2nJeZQ5MlBDECIRZYwrZp5A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "0.0.0-experimental-33c3af284"
 
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -7116,7 +7115,15 @@ react-router@5.2.0, react-router@^5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react@^16.13.1, react@^16.7.0:
+react@^0.0.0-experimental-33c3af284:
+  version "0.0.0-experimental-33c3af284"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-33c3af284.tgz#63842e46a441e4d5a8a5623a21791973196e8bbf"
+  integrity sha512-dk0eQhyiA05TYtSWShwfl4vxlJAOrwNLtESbWxM6O06Xn0nuzlXYZUjsY3sJkZrpXK0kywZ+Hbs24tA8u/1KzQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+react@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
@@ -7445,10 +7452,10 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@0.0.0-experimental-33c3af284:
+  version "0.0.0-experimental-33c3af284"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-33c3af284.tgz#69e1db9ceb7cb1b654ff0a0057ea7d4fb23dfbd2"
+  integrity sha512-m9eyhFt9uGi9y3HcN9hMrbnw1AbFEWcWn+IjF1N+GGVGfQmgB0F/mQ9rQkmrX7gPNIDBKwlFdOsrENtHTn4XUQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Adds an experimental feature flag PEXO_EXPERIMENTAL.
If set to `true` it will run the application in concurrent mode.
Currently this is only makes changes to the client, the server is not
affected so far.

There is some more potential to make use of concurrent mode for deferred
values and priorization of components. This might follow as a next step.

This commit contains a breaking change as it renames `Loading` and
`Error` to `LoadingView` and `ErrorView` as the former API for the error
component caused unintended in case `throw new Error()` was used.

Closes #10